### PR TITLE
Fixing issue where correlation ids do not populate on expand

### DIFF
--- a/central-logging/deploy/ADX/Tables/AppExceptions.kql
+++ b/central-logging/deploy/ADX/Tables/AppExceptions.kql
@@ -51,10 +51,10 @@ Expand_AppExceptions() {
     | mv-expand Records
     | extend events = Records
     | extend properties = todynamic(extract_json("$", tostring(events.Properties)))
-    | extend message = todynamic(extract_json("$", tostring(properties.Message)))
+    | extend message = todynamic(extract_json("$", tostring(properties.FormattedMessage)))
     | project
-        ["PrimaryCorrelationId"] = tostring(events.["PrimaryCorrelationId"])
-        ,["SecondaryCorrelationId"] = tostring(events.["SecondaryCorrelationId"])
+        ["PrimaryCorrelationId"] = tostring(properties.["PrimaryCorrelationId"])
+        ,["SecondaryCorrelationId"] = tostring(message.["SecondaryCorrelationId"])
         ,["AppRoleInstance"] = tostring(events.["AppRoleInstance"])
         ,["AppVersion"] = tostring(events.["AppVersion"])
         ,["Assembly"] = tostring(events.["Assembly"])

--- a/central-logging/deploy/modules/adx.bicep
+++ b/central-logging/deploy/modules/adx.bicep
@@ -111,7 +111,7 @@ resource aoiKustoCentralLoggingDatabaseConfig 'Microsoft.Kusto/clusters/database
   parent: aoiKustoCentralLoggingClusterDatabase
   properties: {
     continueOnErrors: true
-    forceUpdateTag: 'v2'
+    forceUpdateTag: 'v2.1'
     scriptContent: databaseConfig.value
   }
 }]


### PR DESCRIPTION
# Description
Fixes #52 - central-logging does not populate primary and secondary correlation ids

- Fixed expand query
- Changed update tag

This has been tested by deploying this branch, validating that the expand was updated in ADX and validated that new exceptions expanded the correlation ids appropriately.

## Dependencies affected:
    - None


## Checklist before merging
- [X] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [NA] Downstream dependencies have been addressed
- [NA] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
 