### PR TITLE
start of CODEOWNERS file. 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,13 +11,3 @@
 *.ts @micholas
 *.cs @scschneider @srajtiwari
 *.bicep @scschneider @srajtiwari  @CheyYeary 
-
-# Directory owners
-/tcp-to-blob/                @micholas
-/orbital-helper/             @micholas
-/central-logging/            @scschneider
-/blob-download-service/      @scschneider
-/aqua-processor/             @scschneider
-/.github/workflows/          @CheyYeary
-
-# File owners


### PR DESCRIPTION
Any PR with TS/JS will add Mick be to reviewers and C# changes will add Steven to reviewers.

# Description
Fixes #46

CODEOWNERS file will assign reviewers based on different criteria specified in file. For now, ours is set to look for js/ts extension and c# extension. If any files with those three extensions have been modified a reviewer will automatically be assigned. 

## Dependencies affected:
- N/A

## Checklist before merging
- [X] Properly labeled PR 
- [X] Licensing statement added to new files 
- [X] Downstream dependencies have been addressed
- [X] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
