### PR TITLE
removing only hardcoded deployment name. Added Name Prefix.

### DIFF
--- a/central-logging/deploy/deploy.sh
+++ b/central-logging/deploy/deploy.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 WORKING_DIR="$(dirname "$0")"
 
 az deployment sub create \
-  --name "aoi-central-logging" \
+  --name "${NAME_PREFIX}-deployment" \
   --location ${AZ_LOCATION} \
   --template-file ${WORKING_DIR}/main.bicep \
   --parameters \

--- a/examples/aqua-processor/deploy/deploy.sh
+++ b/examples/aqua-processor/deploy/deploy.sh
@@ -12,7 +12,7 @@ INOTIFY_RTSTPS_ARTIFACTS_DIR="${WORKING_DIR}/artifacts/linux-x64/inotify-rtstps"
 ARTIFACTS_CONTAINER_NAME="artifacts"
 
 # Deploy some prerequisites, capture the outputs from the deployment and create vars from the required outputs
-PREREQ_DEPLOYMENT_OUTPUT=$(az deployment sub create --name "aoi-aqua-prereq" --location ${AZ_LOCATION} --template-file ${WORKING_DIR}/prereq.bicep --parameters location="${AZ_LOCATION}" namePrefix="${NAME_PREFIX}" --query "properties.outputs" -o json)
+PREREQ_DEPLOYMENT_OUTPUT=$(az deployment sub create --name "${NAME_PREFIX}-prereq" --location ${AZ_LOCATION} --template-file ${WORKING_DIR}/prereq.bicep --parameters location="${AZ_LOCATION}" namePrefix="${NAME_PREFIX}" --query "properties.outputs" -o json)
 
 APPLICATION_INSIGHTS_APP_NAME=$(echo ${PREREQ_DEPLOYMENT_OUTPUT} | jq -r '.applicationInsightsName.value')
 APPLICATION_INSIGHTS_RG=$(echo ${PREREQ_DEPLOYMENT_OUTPUT} | jq -r '.applicationInsightsRg.value')
@@ -30,7 +30,7 @@ az storage blob upload --account-name ${STORAGE_ACCOUNT_NAME} --container-name $
 
 
 az deployment sub create \
-  --name "aoi-aqua-main" \
+  --name "${NAME_PREFIX}-main" \
   --location ${AZ_LOCATION} \
   --template-file ${WORKING_DIR}/main.bicep \
   --parameters \


### PR DESCRIPTION
# Description
Fixes #101

 Removed hardcoded deployment names and followed existing pattern of NAME_PREFIX env variable as start of --name value on deployments. 

## Dependencies affected:
- None

## Checklist before merging
- [X] Properly labeled PR 
- [X] Licensing statement added to new files 
- [X] Downstream dependencies have been addressed
- [X] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
