### PR TITLE
Fixing github action to build file-event-service

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -8,7 +8,7 @@ on: push
 jobs:
   build:
   
-    name: build blob download service
+    name: build FileEventService
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -21,6 +21,6 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies
-        run: cd blob-download-service/src/ && dotnet restore
+        run: cd file-event-service/src/ && dotnet restore
       - name: Build
-        run: cd blob-download-service/src/ && dotnet build --no-restore 
+        run: cd file-event-service/src/ && dotnet build --no-restore 


### PR DESCRIPTION
# Description
Fixes #132

Replacing blob-download-service with file-event-service

## Dependencies affected:
- NA

## Checklist before merging
- [X] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [NA] Downstream dependencies have been addressed
- [NA] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
