### PR TITLE
TCP-to-blob README changes

### DIFF
--- a/tcp-to-blob/README.md
+++ b/tcp-to-blob/README.md
@@ -6,7 +6,18 @@
 
 # TCP-to-BLOB
 
-TCP to BLOB is a kubernetes service that provides a TCP endpoint to receive [Azure Orbital Ground Station (AOGS)](https://docs.microsoft.com/en-us/azure/orbital/overview) satellite downlink data and persists it in Azure BLOB Storage.
+TCP to BLOB is a kubernetes service that provides a TCP endpoint to receive [Azure Orbital Ground Station (AOGS)](https://docs.microsoft.com/en-us/azure/orbital/overview) satellite downlink data and persists it in Azure BLOB Storage. This doc shows you how to deploy this architecture into Azure using the resources and code in this repository.
+
+## Prerequisites
+
+- NodeJS LTS (16 or later)
+- [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) (recommended) You can use `npm`, but README
+  uses `yarn`
+- Azure subscription access
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+- [AKS CLI](https://docs.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli): `az aks install-cli`. The deployment scripts use [kubectl](https://kubernetes.io/docs/tasks/tools/) (not AKS CLI) but it's probably safest to use the `kubectl` that comes with the AKS CLI.
+- Docker
+- Virtual Machine or personal environment for execution
 
 ## High level components
 
@@ -31,16 +42,6 @@ TCP to BLOB is a kubernetes service that provides a TCP endpoint to receive [Azu
    socket)
 7. `complete`: Final event providing success/failure summary. (1 per socket)
 
-## Prerequisites
-
-- NodeJS LTS (16 or later)
-- [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable) (recommended) You can use `npm`, but README
-  uses `yarn`
-- Azure subscription access
-- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
-- [AKS CLI](https://docs.microsoft.com/en-us/azure/aks/learn/quick-kubernetes-deploy-cli): `az aks install-cli`. The deployment scripts use [kubectl](https://kubernetes.io/docs/tasks/tools/) (not AKS CLI) but it's probably safest to use the `kubectl` that comes with the AKS CLI.
-- Docker
-
 ## Install NodeJS dependencies
 
 From `azure-orbital-integration` project root directory, run:
@@ -55,6 +56,12 @@ package.json to determine what script are available.
 
 If for some reason you prefer to not run the with `yarn` or `npm`, you can consider the `scripts` in package.json as
 examples.
+
+## Create environment file
+
+1. `cd tcp-to-blob && mkdir .env`
+2. `cp ./deploy/env-template.sh .env/env-<name_prefix>.sh`
+3. Edit your env file as needed. See: "Environment variables" section above.
 
 ## Environment variables
 
@@ -95,12 +102,6 @@ Optional:
 
 Recommend creating a `tcp-to-blob/.env/env-${stage}.sh` to set these and re-load env as needed without risking
 committing them to version control.
-
-## Create environment file
-
-1. `cd tcp-to-blob && mkdir .env`
-2. `cp ./deploy/env-template.sh .env/env-<name_prefix>.sh`
-3. Edit your env file as needed. See: "Environment variables" section above.
 
 ## Deploy environment to Azure Kubernetes Service (AKS)
 


### PR DESCRIPTION
# Description
Fixes #142 

Updates to TCP-to-blob README.md:
- Under H1, added requested descriptive verbiage
- Moved pre-reqs to be first H2 section
- Added line for need of VM or local environment in pre-reqs
- In H2, moved env. vars. to after create env. file

## Dependencies affected:
- 

## Checklist before merging
- [x] Properly labeled PR 
- [] Licensing statement added to new files 
- [] Downstream dependencies have been addressed
- [] Corresponding changes to the documentation have been made
- [] Issue is linked under the development section
