### PR TITLE
added lifecycle policy to storage account for tcp-to-blob. Deletes fi…

### DIFF
--- a/tcp-to-blob/deploy/bicep/storage.bicep
+++ b/tcp-to-blob/deploy/bicep/storage.bicep
@@ -51,6 +51,36 @@ resource rscStorage 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   }
 }
 
+resource rscPolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2022-05-01' = {
+  name: 'default'
+  parent: rscStorage
+  properties: {
+    policy: {
+      rules: [
+        {
+          definition: {
+            actions: {
+              baseBlob: {
+                delete: {
+                  daysAfterCreationGreaterThan: 7
+                }
+              }
+            }
+            filters: {
+            blobTypes: [
+              'blockBlob'
+            ]
+            }
+          }
+          enabled: true
+          name: 'deleteAfter7Days'
+          type: 'Lifecycle'
+        }
+      ]
+    }
+  }
+}
+
 @description('https://docs.microsoft.com/en-us/azure/templates/microsoft.eventgrid/systemtopics?pivots=deployment-language-bicep')
 resource eventGridSystemTopic 'Microsoft.EventGrid/systemTopics@2022-06-15' = {
   name: '${name}-contact-data-created'

--- a/tcp-to-blob/deploy/bicep/storage.bicep
+++ b/tcp-to-blob/deploy/bicep/storage.bicep
@@ -70,6 +70,9 @@ resource rscPolicy 'Microsoft.Storage/storageAccounts/managementPolicies@2022-05
             blobTypes: [
               'blockBlob'
             ]
+            prefixMatch: [
+              'raw-contact-data/canary'
+            ]
             }
           }
           enabled: true

--- a/tcp-to-blob/src/tcp-to-blob.ts
+++ b/tcp-to-blob/src/tcp-to-blob.ts
@@ -59,10 +59,11 @@ if (require.main === module) {
             ) {
                 sender = 'canary'
             }
-            const filename = `tcp_data_${timestampStr}_${sender}_${remoteToken}.${sender=='canary'? 'txt':'bin'}`
+            const localFileName = `tcp_data_${timestampStr}_${sender}_${remoteToken}.${sender=='canary'? 'txt':'bin'}`
+            const filename = `${sender}/${localFileName}`
             const logger = makeLogger({
                 subsystem: 'tcp-to-blob',
-                filename,
+                localFileName,
                 localPort: port,
                 remoteHost,
                 remotePort,
@@ -132,12 +133,12 @@ if (require.main === module) {
                     try {
                         fileAppender = makeFileAppender({
                             dirPath: '/tmp/output',
-                            filename,
+                            filename: localFileName,
                         })
                         const msg = {
                             message: 'Creating file.',
                             event: 'socket-data',
-                            filename,
+                            filename: localFileName,
                             ...makeMsgData(),
                         }
 

--- a/tcp-to-blob/src/tcp-to-blob.ts
+++ b/tcp-to-blob/src/tcp-to-blob.ts
@@ -63,7 +63,7 @@ if (require.main === module) {
             const filename = `${sender}/${localFileName}`
             const logger = makeLogger({
                 subsystem: 'tcp-to-blob',
-                localFileName,
+                filename,
                 localPort: port,
                 remoteHost,
                 remotePort,


### PR DESCRIPTION
…les after 7 days

# Description
Fixes #149

Added a lifecycle policy of 7 days at the base of our storage account. This currently policy is a blanket statement for all files in the container. 

Tested successfully on another stack. The policy rules can take up to 24 hours to run after being deployed. 

## Dependencies affected:
- 

## Checklist before merging
- [X] Properly labeled PR 
- [X] Licensing statement added to new files 
- [X] Downstream dependencies have been addressed
- [X] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
