### PR TITLE
Fixing a couple issues with directory parsing

### DIFF
--- a/file-event-service/src/Actions/BlobUploadEventAction.cs
+++ b/file-event-service/src/Actions/BlobUploadEventAction.cs
@@ -46,7 +46,7 @@ namespace FileEventService.Actions
         {
             FileMetadata data = JsonUtils.DeserializeObject<FileMetadata>(eventGridMessage.Data.ToString());
 
-            string filePath = Path.Combine(_options.FilePath, data.RelativeFilePath);
+            string filePath = $"{Path.TrimEndingDirectorySeparator(_options.FilePath)}{data.RelativeFilePath}";
             string lowerContainerName = _options.ContainerName.ToLowerInvariant();
             var evt = $"{_className}::{nameof(ProcessEventAsync)}";
             var msg = $"Starting blob upload to, '{lowerContainerName}/{filePath}'.";

--- a/file-event-service/src/Models/FileMetadata.cs
+++ b/file-event-service/src/Models/FileMetadata.cs
@@ -53,7 +53,7 @@ namespace FileEventService.Models
             // ./d1 becomes /d1
             if (pathToWatch.StartsWith('.'))
             {
-                pathToWatch = pathToWatch.Substring(1, pathToWatch.Length);
+                pathToWatch = pathToWatch.Substring(1, pathToWatch.Length - 1);
             }
 
             // Split on the pathToWatch and take the second value,


### PR DESCRIPTION
# Description
Fixes #160 

This fixes the directory sub folder issue when uploading to blob store. This also fixes an issue when we detect a leading `.` and drop it, we need to also deduct the length by 1.

## Dependencies affected:
- NA

## Checklist before merging
- [X] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [NA] Downstream dependencies have been addressed
- [NA] Corresponding changes to the documentation have been made
- []X Issue is linked under the development section
