### PR TITLE
installing extra packages repository so jq can be found

### DIFF
--- a/examples/aqua-processor/deploy/file-event-service/install-file-event-service.sh
+++ b/examples/aqua-processor/deploy/file-event-service/install-file-event-service.sh
@@ -19,6 +19,8 @@ mkdir -p ${LOCAL_ARTIFACTS_FOLDER}
 tar -zvxf ./file-event-service-artifacts.tar.gz -C ${LOCAL_ARTIFACTS_FOLDER}
 
 # Install FileEventService
+yum install -y epel-release
+yum update -y
 yum install -y libicu
 yum install -y jq
 mkdir -p ${FES_INSTALL_FOLDER}


### PR DESCRIPTION
# Description
Fixes #169 

We can now install jq within aqua-processor.

## Dependencies affected:
- NA

## Checklist before merging
- [X] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [NA] Downstream dependencies have been addressed
- [NA] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
