### PR TITLE
Adding topic capabilities and blob upload file mime type

### DIFF
--- a/examples/aqua-processor/deploy/file-event-service/file-event-service.template.json
+++ b/examples/aqua-processor/deploy/file-event-service/file-event-service.template.json
@@ -5,7 +5,7 @@
       "type": "ServiceBus",
       "name": "contact-data-created",
       "connectionString": "${SERVICE_BUS_CONNECTION_STRING}",
-      "queueName": "${SERVICE_BUS_QUEUE_NAME}",
+      "topicOrQueueName": "${SERVICE_BUS_QUEUE_NAME}",
       "actions": [
         {
           "type": "BlobDownload",

--- a/file-event-service/README.md
+++ b/file-event-service/README.md
@@ -43,7 +43,8 @@ Provides functionality to receive Event Grid messages by way of Service Bus, spe
   "type": "string",
   "name": "string",
   "connectionString": "string",
-  "queueName": "string",
+  "topicOrQueueName": "string",
+  "subscriptionName": "string",
   "actions": [/* Array of action objects */],
   "allowedEventTypes": [/* Array of strings */]
 }
@@ -54,7 +55,8 @@ Provides functionality to receive Event Grid messages by way of Service Bus, spe
 |type|Specifies the event listener type, supported type `ServiceBus`|
 |name|A unique name that would help distinguish one event listener from another. This name is helpful for parsing logs.|
 |connectionString|The connection string used for authenticating with Service Bus.|
-|queueName|The Service Bus queue name where messages are received.|
+|topicOrQueueName|The Service Bus topic or queue name where messages are received. If subscriptionName is not specified, we assume queue.|
+|subscriptionName|The subscription name associated with a given topic.|
 |actions|A collection of actions to execute when an event is received. [See Event Actions](#event-actions)|
 |allowedEventTypes|A string collection of event types, i.e. Microsoft.Blob.Created. [See available event types](https://docs.microsoft.com/en-us/azure/event-grid/event-schema-blob-storage?tabs=event-grid-event-schema#available-event-types) for a complete list.|
 

--- a/file-event-service/src/FileEventService.csproj
+++ b/file-event-service/src/FileEventService.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.9.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="NewtonSoft.Json" Version="13.0.1" />

--- a/file-event-service/src/Listeners/Options/ServiceBusListenerOptions.cs
+++ b/file-event-service/src/Listeners/Options/ServiceBusListenerOptions.cs
@@ -13,7 +13,8 @@ namespace FileEventService.Listeners.Options
         public EventListenerType Type { get; set; }
         public string Name { get; set; }
         public string ConnectionString { get; set; }
-        public string QueueName { get; set; }
+        public string TopicOrQueueName { get; set; }
+        public string SubscriptionName { get; set; } = string.Empty;
         public int MaxAutoLockRenewalSeconds { get; set; } = 1800;
         public int MaxConcurrentCalls { get; set; } = 5;
         public dynamic[] Actions { get; set; }
@@ -25,7 +26,8 @@ namespace FileEventService.Listeners.Options
             {
                 Name = Name,
                 ConnectionString = Constants.RedactedSecretMask,
-                QueueName = QueueName,
+                TopicOrQueueName = TopicOrQueueName,
+                SubscriptionName = SubscriptionName,
                 MaxAutoLockRenewalSeconds = MaxAutoLockRenewalSeconds,
                 MaxConcurrentCalls = MaxConcurrentCalls,
                 Actions = new string[] { Constants.RedactedSecretMask },

--- a/file-event-service/src/Listeners/ServiceBusEventListener.cs
+++ b/file-event-service/src/Listeners/ServiceBusEventListener.cs
@@ -46,8 +46,11 @@ namespace FileEventService.Listeners
 
             return new ServiceBusEventListener
             {
-                _processor = new ServiceBusClient(options.ConnectionString)
-                    .CreateProcessor(options.QueueName, serviceBusOptions),
+                _processor = String.IsNullOrWhiteSpace(options.SubscriptionName) ?
+                    new ServiceBusClient(options.ConnectionString)
+                        .CreateProcessor(options.TopicOrQueueName, serviceBusOptions) :
+                    new ServiceBusClient(options.ConnectionString)
+                        .CreateProcessor(options.TopicOrQueueName, options.SubscriptionName, serviceBusOptions),
                 _name = options.Name,
                 _options = options,
                 _allowedEventTypes = options.AllowedEventTypes,

--- a/file-event-service/src/file-event-service.sample.json
+++ b/file-event-service/src/file-event-service.sample.json
@@ -5,7 +5,7 @@
       "type": "ServiceBus",
       "name": "MyServiceBusReceiver",
       "connectionString": "",
-      "queueName": "blob-created",
+      "topicOrQueueName": "blob-created",
       "actions": [
         {
           "type": "BlobDownload",


### PR DESCRIPTION
# Description
Fixes #174 

- Allows a user to leverage Service Bus topics.
- Blobs will have their content/mime type set during upload.

## Dependencies affected:
- examples/aqua-processor/deploy/file-event-service.template.json updated JSON property name accordingly.

## Checklist before merging
- [X] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [X] Downstream dependencies have been addressed
- [X] Corresponding changes to the documentation have been made
- [X] Issue is linked under the development section
