### PR TITLE
Create the tar file outside the directory containing the archiving files

### DIFF
--- a/examples/aqua-processor/deploy/file-event-service/prepare-artifacts.sh
+++ b/examples/aqua-processor/deploy/file-event-service/prepare-artifacts.sh
@@ -42,4 +42,7 @@ cat ${WORKING_DIR}/file-event-service.template.json | \
 cp ${WORKING_DIR}/FileEventService.service ${ARTIFACTS_DIR}
 cp ${WORKING_DIR}/run-nasa-tools.sh ${ARTIFACTS_DIR}
 
-tar -czvf "${ARTIFACTS_DIR}/file-event-service-artifacts.tar.gz" -C ${ARTIFACTS_DIR} .
+tar -czvf /tmp/file-event-service-artifacts.tar.gz -C ${ARTIFACTS_DIR} .
+
+mv /tmp/file-event-service-artifacts.tar.gz ${ARTIFACTS_DIR}
+


### PR DESCRIPTION
# Description
Moving the tar file creation outside of `ARTIFACTS_DIR` in `/tmp`. This is to avoid the tar command trying to pack the tar file itself when created in the same directory as other archiving files. 

Below is the tar error I received when running the `deploy.sh` under `aqua-processor`.

`tar: .: file changed as we read it`

## Dependencies affected:
- No, I'm moving the tarball back to the `ARTIFACTS_DIR`

## Checklist before merging
- [Yes] Properly labeled PR 
- [NA] Licensing statement added to new files 
- [Yes] Downstream dependencies have been addressed
- [NA] Corresponding changes to the documentation have been made
- [No] Issue is linked under the development section
