### PR TITLE
Minor fixes

### DIFF
--- a/examples/aqua-processor/README.md
+++ b/examples/aqua-processor/README.md
@@ -68,12 +68,12 @@ The deployed processor VM is named `aoi-aqua-vm` based on a NAME_PREFIX chosen f
 
 ## Install NASA DRL tools
 
-To install NASA DRL tools, we first need to add support for GUI applications by installing desktop tools and a VNC server on `aoi-aqua-vm` to remotely run GUI applications. 
+To install NASA DRL tools, we first need to add support for GUI applications by installing desktop tools and a VNC server on `aoi-aqua-vm` to remotely run GUI applications. These pre requisites are installed by the deploy script and you can directly go ahead and start the VNC server. If you are deploying the VM manually, then follow the below installation steps.
 
 ### Install Desktop and VNC Server
 Please note that initial ssh authentication will only work from your local machine because the deployment script run in the previous step uses your local public key (id_rsa.pub) to set up passwordless authentication to the processor VM. 
 
-After loggin on from your local machine, you can add public keys to the ~/.ssh/authorized_keys file on the processor VM to allow authentication from differnet machines.  
+After logging on from your local machine, you can add public keys to the ~/.ssh/authorized_keys file on the processor VM to allow authentication from different machines.  
 
 Install desktop tools and vncserver on the `aoi-aqua-vm`.
 ```

--- a/examples/aqua-processor/deploy/cloud-init.yaml
+++ b/examples/aqua-processor/deploy/cloud-init.yaml
@@ -1,15 +1,19 @@
+#cloud-config
+
 # Copyright (c) 2022 Microsoft Corporation. All rights reserved.
 # Software is licensed under the MIT License. See LICENSE in the project
 # root for license information.
 
-#cloud-config
 package_upgrade: true
 packages:
-    - httpd
-    - java-11-openjdk-devel
-    - azure-cli
     - tigervnc-server
-    - xorg-x11-fonts-Type1
-    - uuid-runtime
     - python3
     - python3-requests
+runcmd:
+    - [ yum, "-y", groups, install, "GNOME Desktop" ]
+    - [ sudo, curl, "-L", "https://aka.ms/downloadazcopy-v10-linux", "--output", "/tmp/downloadazcopy-v10-linux" ]
+    - [ sudo, mkdir, "-p", "/tmp/downloadazcopy" ]
+    - [ sudo, tar, "-xvzf", "/tmp/downloadazcopy-v10-linux", "--directory", "/tmp/downloadazcopy" ]
+    - [ sudo, rm, "-f", "/usr/bin/azcopy" ]
+    - [ sudo, cp, "/tmp/downloadazcopy/azcopy_linux_amd64_10.17.0/azcopy", "/usr/bin/" ]
+    - [ sudo, chmod, "755", "/usr/bin/azcopy" ]

--- a/examples/aqua-processor/deploy/file-event-service/install-file-event-service.sh
+++ b/examples/aqua-processor/deploy/file-event-service/install-file-event-service.sh
@@ -32,3 +32,7 @@ cp ${WORKING_DIR}/${LOCAL_ARTIFACTS_FOLDER}/run-nasa-tools.sh ${FES_INSTALL_FOLD
 cp ${WORKING_DIR}/${LOCAL_ARTIFACTS_FOLDER}/FileEventService.service /etc/systemd/system/FileEventService.service
 
 sudo systemctl daemon-reload
+
+sudo systemctl enable FileEventService
+
+sudo systemctl start FileEventService


### PR DESCRIPTION
# Description
For package installations or running commands via cloud-init, it expects `#cloud-config` directive to be present on the first line of the yaml file (customData). Also, revised the list of packages and added steps to install azcopy.
FileEventService to start as part of the deploy script. Also, tested the service starts automatically after a reboot. 

## Dependencies affected:
- No dependencies affected.

## Checklist before merging
- [Y] Properly labeled PR 
- [Y] Licensing statement added to new files 
- [NA] Downstream dependencies have been addressed
- [Y] Corresponding changes to the documentation have been made
- [N] Issue is linked under the development section
